### PR TITLE
Give mistranslations a miss

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -80,6 +80,10 @@ static struct Jitem Pirate_items[] = { { POT_BOOZE, "rum" },
                                         	 { CLUB, "belaying pin" },
                                            { QUARTERSTAFF, "oar"},
                                         	 {0, "" } };
+/* Until a native speaker comes along to translate these items more correctly,
+ * pop this struct out for now. Also, it's currently unclear whether the booze
+ * in-game is in fact sake, or is just a beer that's being *called* sake.
+
 static struct Jitem Japanese_items[] = { { SHORT_SWORD, "wakizashi" },
                                              { BROADSWORD, "ninja-to" },
                                              { FLAIL, "nunchaku" },
@@ -93,6 +97,7 @@ static struct Jitem Japanese_items[] = { { SHORT_SWORD, "wakizashi" },
                                              { FOOD_RATION, "gunyoki" },
                                              { POT_BOOZE, "sake" },
                                              { 0, "" } };
+ */
 
 static struct Jitem Cartomancer_items[] = {
                                             { LARGE_BOX, "deck box" },
@@ -156,9 +161,7 @@ obj_typename(int otyp)
     const char *un = ocl->oc_uname;
     int nn = ocl->oc_name_known;
 
-    if (Role_if(PM_SAMURAI) && Alternate_item_name(otyp,Japanese_items))
-        actualn = Alternate_item_name(otyp,Japanese_items);
-    else if (Role_if(PM_CARTOMANCER) && Alternate_item_name(otyp,Cartomancer_items))
+    if (Role_if(PM_CARTOMANCER) && Alternate_item_name(otyp,Cartomancer_items))
      		actualn = Alternate_item_name(otyp,Cartomancer_items);
     else if (Role_if(PM_PIRATE) && Alternate_item_name(otyp,Pirate_items))
      	actualn = Alternate_item_name(otyp,Pirate_items);
@@ -480,9 +483,7 @@ xname_flags(
     boolean known, dknown, bknown;
 
     buf = nextobuf() + PREFIX; /* leave room for "17 -3 " */
-    if (Role_if(PM_SAMURAI) && Alternate_item_name(typ, Japanese_items))
-        actualn = Alternate_item_name(typ, Japanese_items);
-    else if (Role_if(PM_CARTOMANCER) && Alternate_item_name(typ,Cartomancer_items))
+    if (Role_if(PM_CARTOMANCER) && Alternate_item_name(typ,Cartomancer_items))
      		actualn = Alternate_item_name(typ,Cartomancer_items);
     else if (Role_if(PM_PIRATE) && Alternate_item_name(typ,Pirate_items))
      	actualn = Alternate_item_name(typ,Pirate_items);
@@ -3493,13 +3494,7 @@ const char * in_str;
             return as->ob;
         }
     }
-    /* try Japanese names */
     struct Jitem *j;
-    for (j = Japanese_items; j->item != 0; j++) {
-        if (!strcmpi(in_str, j->name)) {
-            return j->item;
-        }
-    }
     /* try Pirate names */
     for (j = Pirate_items; j->item != 0; j++) {
         if (!strcmpi(in_str, j->name)) {
@@ -3555,7 +3550,7 @@ static int
 readobjnam_preparse(struct _readobjnam_data* d)
 {
     int i;
-    
+
     for (;;) {
         register int l;
 
@@ -4296,7 +4291,7 @@ readobjnam_postparse3(struct _readobjnam_data* d)
     d->typ = 0;
 
     if (d->actualn) {
-        struct Jitem *j[] = {Japanese_items,Pirate_items,Cartomancer_items};
+        struct Jitem *j[] = {Pirate_items,Cartomancer_items};
     		for(i = 0; (unsigned long) i < sizeof(j) / sizeof(j[0]); i++)
     		{
          		while(j[i]->item) {


### PR DESCRIPTION
Since some of the translations seem to be misinformed, let's mark out
those mistakes. This helps reduce the unnecessary exoticism of Nethack's
eurocentric lens.