### PR TITLE
Swap Excalibur and Snickersnee's damage bonuses

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,7 +6,7 @@
 
 ### Species Changes
 - Different species have different night vision ranges.
-- Maximum Dexterity is now 20 for Elves, and 18 for Dwarves. 
+- Maximum Dexterity is now 20 for Elves, and 18 for Dwarves.
 #### Drow
   - Male drow are referred to as "hedrow."
   - Potions of sickness in the starting inventories of drow are replaced by potions of sleeping.
@@ -211,6 +211,8 @@ in its own way.
   their hunger increases the total time of their prayer timeout. This is meant to eliminate slow,
   degenerate play, and should not affect regular players much.
 - While the player is level one, they get hungry much more slowly.
+- Excalibur's and Snickersnee's artifact attack/damage bonuses have been swapped, so
+that Excalibur doesn't crowd out all the other artifact weapons as much.
 
 ### YAFM
 - Whenever you are polymorphed into a bear, all instances of the word "bare" are replaced

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -300,7 +300,7 @@ static NEARDATA struct artifact artilist[] = {
 
     A("Excalibur", LONG_SWORD, (SPFX_NOGEN | SPFX_RESTR | SPFX_SEEK
                                 | SPFX_DEFN | SPFX_INTEL | SPFX_SEARCH),
-      0, 0, PHYS(5, 10), DRLI(0, 0), NO_CARY, HOLY_LANCE, A_LAWFUL, PM_KNIGHT, NON_PM,
+      0, 0, PHYS(0, 8), DRLI(0, 0), NO_CARY, HOLY_LANCE, A_LAWFUL, PM_KNIGHT, NON_PM,
       4000L, NO_COLOR),
     /*
      *      Stormbringer only has a 2 because it can drain a level,
@@ -411,7 +411,7 @@ static NEARDATA struct artifact artilist[] = {
      *                      --Koko, Lord high executioner of Titipu
      *                        (From Sir W.S. Gilbert's "The Mikado")
      */
-    A("Snickersnee", KATANA, SPFX_RESTR, 0, 0, PHYS(0, 8), NO_DFNS, NO_CARY,
+    A("Snickersnee", KATANA, SPFX_RESTR, 0, 0, PHYS(5, 10), NO_DFNS, NO_CARY,
       0, A_LAWFUL, PM_SAMURAI, NON_PM, 1200L, NO_COLOR),
 
     A("Sunsword", LONG_SWORD, (SPFX_RESTR | SPFX_WARN | SPFX_DFLAGH), 0, MH_UNDEAD,


### PR DESCRIPTION
For lawful characters, many artifacts are "good, but there's no reason to
wield this over Excalibur". Take that down a notch by reducing Excalibur's
universal attack and damage bonuses, while leaving the flavor abilities alone.

Snickersnee receives those bonuses instead, solidly becoming the lawful weapon
of choice for dealing large quantities of plain physical damage.