### PR TITLE
Add more abbreviations for wishing

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -3071,6 +3071,11 @@ static const struct alt_spellings {
     { "gdsm", GRAY_DRAGON_SCALE_MAIL },
     { "sdsm", SILVER_DRAGON_SCALE_MAIL },
     { "AoR", AMULET_OF_REFLECTION },
+    { "AoLS", AMULET_OF_LIFE_SAVING },
+    { "wod", WAN_DEATH },
+    { "mkot", ART_MASTER_KEY_OF_THIEVERY },
+    { "oof", ART_ORB_OF_FATE },
+    { "eota", ART_EYE_OF_THE_AETHIOPICA },
     /* Just for fun */
     { "love", SCR_TAMING },
     { "world peace", SCR_TAMING },


### PR DESCRIPTION
aols and wod are pretty common wish targets. so are some quest artis.

Aethiopica is particularly hard for folks to spell, so the abbreviation could
make wishing for it less frustrating.