### PR TITLE
allow the Big Room to spawn up to 3 dungeon levels deeper (fourk/xnh)

### DIFF
--- a/dat/dungeon.lua
+++ b/dat/dungeon.lua
@@ -83,7 +83,7 @@ dungeon = {
             name = "bigrm",
             bonetag = "B",
             base = 10,
-            range = 3,
+            range = 6,
             chance = 40,
             nlevels = 10
          },


### PR DESCRIPTION
aosdict:

> From Fourk. There are a few reasons for doing this:
>   1) When the Big Room and Sokoban entrance both happened to be on level
>      10, Sokoban could be very hard to access. If the player were
>      pursuing a strategy that involved getting to Sokoban early for food
>      or whatever, the dungeon generating like this meant that strategy
>      almost certainly wouldn't work.
>   2) A level-wide mob of monsters is possibly a little too tough for as
>      early as level 10. Though I'm not fully convinced of this; ais523
>      would probably say that it's good to throw a too-difficult
>      challenge at the player every once in a while.
>   3) The level 10-12 range is possibly closer to other levels of
>      interest like the Oracle and Sokoban, whereas the levels after it
>      can get a bit boring what with having nothing interesting in them
>      until Medusa (except maybe the Quest portal).